### PR TITLE
Only run CodeQL workflow on pushes and pull requests.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   codeql:


### PR DESCRIPTION
Since we've pinned the CodeQL version, there's no point running on a schedule anymore.